### PR TITLE
Fix unknown materials error

### DIFF
--- a/files/valve/VPKFile.mjs
+++ b/files/valve/VPKFile.mjs
@@ -149,7 +149,17 @@ export default class VPKFile extends BinaryFile {
         const index = file.EntryOffset;
         const len = file.EntryLength;
 
+		if (file.PreloadBytes !== 0) {
+            return this.concatenate(file.preloadData, buffer.slice(index, index + len));
+        }
         return buffer.slice(index, index + len);
+    }
+	
+	concatenate(buffer1, buffer2) {
+        var tmp = new Uint8Array(buffer1.byteLength + buffer2.byteLength);
+        tmp.set(new Uint8Array(buffer1), 0);
+        tmp.set(new Uint8Array(buffer2), buffer1.byteLength);
+        return tmp.buffer;
     }
 
 }


### PR DESCRIPTION
Some materials were not read correctly due to fact that the only the material data from the archive was returned and not the preloaded data + the data from the archive.

This is fixed by concatenating the preloadData with the data from the archive.